### PR TITLE
Support generating `('a, 'ctx) reader` (by default) or `('a, c) reade…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ instead of:
 
 ```ocaml
 val bin_t : 'a Bin_prot.Type_class.t ‑> 'a t Bin_prot.Type_class.t
-val bin_read_t : 'a Bin_prot.Read.reader ‑> 'a t Bin_prot.Read.reader
-val __bin_read_t__ : 'a Bin_prot.Read.reader ‑> (int ‑> 'a t) Bin_prot.Read.reader
-val bin_reader_t : 'a Bin_prot.Type_class.reader ‑> 'a t Bin_prot.Type_class.reader
+val bin_read_t : ('a, 'ctx) Bin_prot.Read.reader ‑> ('a t, 'ctx) Bin_prot.Read.reader
+val __bin_read_t__ : ('a, 'ctx) Bin_prot.Read.reader ‑> (int ‑> 'a t, 'ctx) Bin_prot.Read.reader
+val bin_reader_t : ('a, 'ctx) Bin_prot.Type_class.reader ‑> ('a t, 'ctx) Bin_prot.Type_class.reader
 val bin_size_t : 'a Bin_prot.Size.sizer ‑> 'a t Bin_prot.Size.sizer
 val bin_write_t : 'a Bin_prot.Write.writer ‑> 'a t Bin_prot.Write.writer
 val bin_writer_t : 'a Bin_prot.Type_class.writer ‑> 'a t Bin_prot.Type_class.writer

--- a/bench/ppx_bin_prot_bench.ml
+++ b/bench/ppx_bin_prot_bench.ml
@@ -5,7 +5,7 @@ let write_bin_prot writer buf ~pos a =
   assert (writer.Bin_prot.Type_class.write buf ~pos a = pos + len)
 ;;
 
-let read_bin_prot reader buf ~pos_ref = reader.Bin_prot.Type_class.read buf ~pos_ref
+let read_bin_prot reader buf ~pos_ref = reader.Bin_prot.Type_class.read ~ctx:() buf ~pos_ref
 let pos_ref = ref 0
 let one = if Random.bool () then 1.0 else 1.0
 let pi = if Random.bool () then 3.141597 else 3.141597

--- a/dune
+++ b/dune
@@ -1,0 +1,1 @@
+(dirs src shape test)

--- a/src/ppx_bin_prot.ml
+++ b/src/ppx_bin_prot.ml
@@ -72,7 +72,14 @@ let bin_size_arg = value_name ~prefix:"_size_of_"
 let bin_write_arg = value_name ~prefix:"_write_"
 let conv_name = value_name ~prefix:"_of__"
 
-module Typ = struct
+type ctx = NoCtx
+         | DefaultCtx
+         | SpecifiedCtx of core_type
+let ctx_wrapper ctx = match ctx with
+  | None -> DefaultCtx
+  | Some c -> SpecifiedCtx c
+
+  module Typ = struct
   type t =
     { type_constr : string
     ; wrap_result : loc:Location.t -> core_type -> core_type
@@ -82,10 +89,11 @@ module Typ = struct
     { type_constr = type_name "Bin_prot.Read.reader" ~locality
     ; wrap_result = (fun ~loc t -> [%type: int -> [%t t]])
     }
-  ;;
 
   let create type_constr ~locality =
-    { type_constr = type_name type_constr ~locality; wrap_result = (fun ~loc:_ x -> x) }
+    { type_constr = type_name type_constr ~locality
+    ; wrap_result = (fun ~loc:_ x -> x)
+    }
   ;;
 end
 (* +-----------------------------------------------------------------+
@@ -93,29 +101,47 @@ end
    +-----------------------------------------------------------------+ *)
 
 module Sig = struct
-  let mk_sig_generator combinators ~with_localize =
-    let mk_sig ~ctxt:_ (_rf, tds) localize =
+  let mk_sig_generator combinators ~with_localize ~with_ctx =
+    let mk_sig ~ctxt:_ (_rf, tds) localize ~ctx_def =
       List.concat_map tds ~f:(fun td ->
         let td = name_type_params_in_td td in
-        List.concat_map combinators ~f:(fun mk -> Staged.unstage mk td ~localize))
+        List.concat_map combinators ~f:(fun mk -> Staged.unstage mk td ~localize ~ctx_def))
     in
-    if with_localize
-    then (
-      let flags = Deriving.Args.(empty +> flag "localize") in
-      Deriving.Generator.V2.make flags mk_sig)
-    else (
-      let flags = Deriving.Args.empty in
-      Deriving.Generator.V2.make flags (fun ~ctxt x -> mk_sig ~ctxt x false))
+    let localize_flag = Deriving.Args.flag "localize"
+    and ctx_flag = Deriving.Args.(arg "ctx" (pexp_constraint drop __))
+    in
+    match (with_localize, with_ctx) with 
+    | (false, false) ->
+        (*Hardcode: `localize` is false, `ctx` is `NoCtx`*)
+        Deriving.Generator.V2.make Deriving.Args.empty (fun ~ctxt x -> mk_sig ~ctxt x false ~ctx_def:NoCtx)
+    | (false, true) ->
+        Deriving.Generator.V2.make Deriving.Args.(
+          empty +> ctx_flag
+        ) (fun ~ctxt x ctx -> mk_sig ~ctxt x false ~ctx_def:(ctx_wrapper ctx))
+    | (true, false) ->
+        Deriving.Generator.V2.make Deriving.Args.(
+          empty +> localize_flag
+        ) (fun ~ctxt x localize -> mk_sig ~ctxt x localize ~ctx_def:NoCtx)
+    | (true, true) -> 
+        Deriving.Generator.V2.make Deriving.Args.(
+          empty +> localize_flag +> ctx_flag
+        ) (fun ~ctxt x localize ctx -> mk_sig ~ctxt x localize ~ctx_def:(ctx_wrapper ctx))
   ;;
 
-  let mk_typ ~hide_params { Typ.type_constr; wrap_result } td =
+  let mk_typ ~hide_params { Typ.type_constr; wrap_result } ~ctx_def td =
     let loc = td.ptype_loc in
     let id = Longident.parse type_constr in
+    let ctx_type ~loc = match ctx_def with
+    | NoCtx -> []
+    | DefaultCtx -> [ ptyp_var ~loc "ctx" ]
+    | SpecifiedCtx typ -> [ typ ]
+    in
     let wrap_type ~loc t =
       ptyp_constr
         ~loc
         (Located.mk ~loc id)
-        [ (if hide_params then ptyp_any ~loc:td.ptype_name.loc else t) ]
+        ([ (if hide_params then ptyp_any ~loc:td.ptype_name.loc else t) ]
+         @ ctx_type ~loc)
     in
     let result_type =
       wrap_type
@@ -128,11 +154,11 @@ module Sig = struct
   ;;
 
   let mk ~can_generate_local name_format type_constr =
-    Staged.stage (fun td ~localize:localize_requested ->
+    Staged.stage (fun td ~localize:localize_requested ~ctx_def ->
       let generate ~locality =
         let loc = td.ptype_loc in
         let name = Loc.map ~f:(name_format ~locality) td.ptype_name in
-        let typ = mk_typ ~hide_params:false (type_constr ~locality) td in
+        let typ = mk_typ ~hide_params:false (type_constr ~locality) ~ctx_def td in
         psig_value ~loc (value_description ~loc ~name ~type_:typ ~prim:[])
       in
       if can_generate_local && localize_requested
@@ -143,6 +169,7 @@ module Sig = struct
   let bin_write =
     mk_sig_generator
       ~with_localize:true
+      ~with_ctx:false
       [ mk bin_size_name (Typ.create "Bin_prot.Size.sizer") ~can_generate_local:true
       ; mk bin_write_name (Typ.create "Bin_prot.Write.writer") ~can_generate_local:true
       ; mk
@@ -155,6 +182,7 @@ module Sig = struct
   let bin_read =
     mk_sig_generator
       ~with_localize:false
+      ~with_ctx:true
       [ mk bin_read_name (Typ.create "Bin_prot.Read.reader") ~can_generate_local:false
       ; mk bin_vtag_read_name Typ.vtag_reader ~can_generate_local:false
       ; mk
@@ -167,6 +195,7 @@ module Sig = struct
   let bin_type_class =
     mk_sig_generator
       ~with_localize:false
+      ~with_ctx:true
       [ mk bin_name (Typ.create "Bin_prot.Type_class.t") ~can_generate_local:false ]
   ;;
 
@@ -288,11 +317,12 @@ end = struct
   ;;
 end
 
-let generate_poly_type ~loc constructor td =
+let generate_poly_type ~loc ~ctx_def constructor td =
+  let params = List.map td.ptype_params ~f:get_type_param_name in
   ptyp_poly
     ~loc
-    (List.map td.ptype_params ~f:get_type_param_name)
-    (Sig.mk_typ ~hide_params:false constructor td)
+    params
+    (Sig.mk_typ ~hide_params:false ~ctx_def constructor td)
 ;;
 
 let make_value
@@ -303,6 +333,7 @@ let make_value
   ~make_value_name
   ~make_arg_name
   ~body
+  ~ctx_def
   td
   =
   let vars = vars_of_params td ~f:make_arg_name ~locality in
@@ -310,8 +341,8 @@ let make_value
   let expr = eabstract ~loc (patts_of_vars vars) body in
   let constraint_ =
     if hide_params
-    then Sig.mk_typ ~hide_params (type_constr ~locality) td
-    else generate_poly_type ~loc (type_constr ~locality) td
+    then Sig.mk_typ ~hide_params ~ctx_def (type_constr ~locality) td
+    else generate_poly_type ~ctx_def ~loc (type_constr ~locality) td
   in
   let pat, expr =
     (* When [constraint_] has universally quantified type variables, we need to put the
@@ -787,6 +818,7 @@ module Generate_bin_size = struct
       ~make_value_name:bin_size_name
       ~make_arg_name:bin_size_arg
       ~body
+      ~ctx_def:NoCtx 
       td
   ;;
 
@@ -1176,6 +1208,7 @@ module Generate_bin_write = struct
       ~make_value_name:bin_write_name
       ~make_arg_name:bin_write_arg
       ~body
+      ~ctx_def:NoCtx 
       td
   ;;
 
@@ -1203,6 +1236,7 @@ module Generate_bin_write = struct
       ~make_value_name:bin_writer_name
       ~make_arg_name:bin_writer_name
       ~body
+      ~ctx_def:NoCtx 
       td
   ;;
 
@@ -1282,13 +1316,13 @@ module Generate_bin_read = struct
   let bin_read_path_fun loc id args = mk_abst_call { loc with loc_ghost = true } id args
 
   let get_closed_expr loc = function
-    | `Open expr -> [%expr fun buf ~pos_ref -> [%e expr]]
+    | `Open expr -> [%expr fun ~ctx buf ~pos_ref -> [%e expr]]
     | `Closed expr -> expr
   ;;
 
   let get_open_expr loc = function
     | `Open expr -> expr
-    | `Closed expr -> [%expr [%e expr] buf ~pos_ref]
+    | `Closed expr -> [%expr [%e expr] ~ctx buf ~pos_ref]
   ;;
 
   (* Conversion of arguments *)
@@ -1416,7 +1450,7 @@ module Generate_bin_read = struct
         | Rinherit ty ->
           let call =
             [%expr
-              ([%e mk_internal_call full_type_name ty.ptyp_loc ty] buf ~pos_ref vint
+              ([%e mk_internal_call full_type_name ty.ptyp_loc ty] ~ctx buf ~pos_ref vint
                 :> [%t full_type])]
           in
           let expr =
@@ -1442,7 +1476,7 @@ module Generate_bin_read = struct
       let full_type_name = full_type_name_or_anonymous full_type_name in
       `Open
         [%expr
-          let vint = Bin_prot.Read.bin_read_variant_int buf ~pos_ref in
+          let vint = Bin_prot.Read.bin_read_variant_int ~ctx buf ~pos_ref in
           try [%e code] with
           | Bin_prot.Common.No_variant_match ->
             Bin_prot.Common.raise_variant_wrong_type
@@ -1460,7 +1494,7 @@ module Generate_bin_read = struct
           ~pat:(pvar ~loc (conv_name parm.txt ~locality))
           ~expr:
             [%expr
-              fun _buf ~pos_ref ->
+              fun ~ctx:_ buf ~pos_ref ->
                 Bin_prot.Common.raise_read_error
                   (Bin_prot.Common.ReadError.Poly_rec_bound
                      [%e estring ~loc full_type_name])
@@ -1528,7 +1562,7 @@ module Generate_bin_read = struct
     `Open
       (pexp_match
          ~loc
-         [%expr [%e read_fun] buf ~pos_ref]
+         [%expr [%e read_fun] ~ctx buf ~pos_ref]
          (mcs
           @ [ case
                 ~lhs:(ppat_any ~loc)
@@ -1552,7 +1586,7 @@ module Generate_bin_read = struct
     let full_type_name = Full_type_name.get_exn ~loc full_type_name in
     `Closed
       [%expr
-        fun _buf ~pos_ref ->
+        fun ~ctx:_ _buf ~pos_ref ->
           Bin_prot.Common.raise_read_error
             (Bin_prot.Common.ReadError.Empty_type [%e estring ~loc full_type_name])
             !pos_ref]
@@ -1583,9 +1617,9 @@ module Generate_bin_read = struct
     let full_type_name = full_type_name_or_anonymous full_type_name in
     let vtag_read_expr = evar ~loc vtag_read_name in
     [%expr
-      fun buf ~pos_ref ->
-        let vint = Bin_prot.Read.bin_read_variant_int buf ~pos_ref in
-        try [%e eapply ~loc vtag_read_expr (exprs_of_vars args)] buf ~pos_ref vint with
+      fun ~ctx buf ~pos_ref ->
+        let vint = Bin_prot.Read.bin_read_variant_int ~ctx buf ~pos_ref in
+        try [%e eapply ~loc vtag_read_expr (exprs_of_vars args)] ~ctx buf ~pos_ref vint with
         | Bin_prot.Common.No_variant_match ->
           let err = Bin_prot.Common.ReadError.Variant [%e estring ~loc full_type_name] in
           Bin_prot.Common.raise_read_error err !pos_ref]
@@ -1622,7 +1656,7 @@ module Generate_bin_read = struct
   let variant_wrong_type ~loc full_type_name =
     let full_type_name = full_type_name_or_anonymous full_type_name in
     [%expr
-      fun _buf ~pos_ref _vint ->
+      fun ~ctx:_ _buf ~pos_ref _vint ->
         Bin_prot.Common.raise_variant_wrong_type [%e estring ~loc full_type_name] !pos_ref]
   ;;
 
@@ -1642,7 +1676,7 @@ module Generate_bin_read = struct
              ->
              let full_type_name = Full_type_name.get_exn ~loc full_type_name in
              [%expr
-               fun _buf ~pos_ref _vint ->
+               fun ~ctx:_ _buf ~pos_ref _vint ->
                  Bin_prot.Common.raise_read_error
                    (Bin_prot.Common.ReadError.Silly_type [%e estring ~loc full_type_name])
                    !pos_ref]
@@ -1653,7 +1687,7 @@ module Generate_bin_read = struct
              let cnv_expr = cnv expr in
              alias_or_fun
                cnv_expr
-               [%expr fun buf ~pos_ref vint -> [%e cnv_expr] buf ~pos_ref vint]
+               [%expr fun ~ctx buf ~pos_ref vint -> [%e cnv_expr] ~ctx buf ~pos_ref vint]
            | _ ->
              let s = Pprintast.string_of_expression e in
              Location.raise_errorf ~loc "ppx_bin_prot: impossible case: %s" s
@@ -1662,8 +1696,8 @@ module Generate_bin_read = struct
        | _ -> variant_wrong_type ~loc full_type_name)
     | Polymorphic_variant { all_atoms } ->
       (match oc_body with
-       | `Open body when all_atoms -> [%expr fun _buf ~pos_ref:_ vint -> [%e body]]
-       | `Open body -> [%expr fun buf ~pos_ref vint -> [%e body]]
+       | `Open body when all_atoms -> [%expr fun ~ctx:_ _buf ~pos_ref:_ vint -> [%e body]]
+       | `Open body -> [%expr fun ~ctx buf ~pos_ref vint -> [%e body]]
        | _ -> assert false (* impossible *))
     | Other -> variant_wrong_type ~loc full_type_name
   ;;
@@ -1687,8 +1721,8 @@ module Generate_bin_read = struct
         | Alias_but_not_polymorphic_variant | Other ->
           (match oc_body with
            | `Closed expr ->
-             alias_or_fun expr [%expr fun buf ~pos_ref -> [%e expr] buf ~pos_ref]
-           | `Open body -> [%expr fun buf ~pos_ref -> [%e body]])
+             alias_or_fun expr [%expr fun ~ctx buf ~pos_ref -> [%e expr] ~ctx buf ~pos_ref]
+           | `Open body -> [%expr fun ~ctx buf ~pos_ref -> [%e body]])
       in
       let pat = pvar ~loc read_name in
       let pat_with_type =
@@ -1724,7 +1758,12 @@ module Generate_bin_read = struct
     [%expr { read = [%e read]; vtag_read = [%e vtag_read] }]
   ;;
 
-  let bin_read_td ~should_omit_type_params ~loc:_ ~path td =
+  (** Auxiliary function: take a type definition, return
+  - vtag read bindings
+  - read bindings
+  - reader (typeclass) bindings
+  *)
+  let bin_read_td ~should_omit_type_params ~loc:_ ~path ~ctx_def td =
     let full_type_name = Full_type_name.make ~path td in
     let loc = td.ptype_loc in
     let oc_body = reader_body_of_td td full_type_name in
@@ -1738,8 +1777,8 @@ module Generate_bin_read = struct
       if should_omit_type_params
       then None, None
       else
-        ( Some (generate_poly_type ~loc (Typ.vtag_reader ~locality) td)
-        , Some (generate_poly_type ~loc (Typ.create "Bin_prot.Read.reader" ~locality) td)
+        ( Some (generate_poly_type ~ctx_def ~loc (Typ.vtag_reader ~locality) td)
+        , Some (generate_poly_type ~ctx_def ~loc (Typ.create "Bin_prot.Read.reader" ~locality) td)
         )
     in
     let read_binding, vtag_read_binding =
@@ -1758,11 +1797,11 @@ module Generate_bin_read = struct
     let vars = vars_of_params td ~f:bin_reader_name ~locality in
     let read =
       let call = project_vars (evar ~loc read_name) vars ~field_name:"read" in
-      alias_or_fun call [%expr fun buf ~pos_ref -> [%e call] buf ~pos_ref]
+      alias_or_fun call [%expr fun ~ctx buf ~pos_ref -> [%e call] ~ctx buf ~pos_ref]
     in
     let vtag_read =
       let call = project_vars (evar ~loc vtag_read_name) vars ~field_name:"read" in
-      alias_or_fun call [%expr fun buf ~pos_ref vtag -> [%e call] buf ~pos_ref vtag]
+      alias_or_fun call [%expr fun ~ctx buf ~pos_ref vtag -> [%e call] ~ctx buf ~pos_ref vtag]
     in
     let reader_binding =
       let body = reader_type_class_record ~loc ~read ~vtag_read in
@@ -1774,13 +1813,14 @@ module Generate_bin_read = struct
         ~make_value_name:bin_reader_name
         ~make_arg_name:bin_reader_name
         ~body
+        ~ctx_def
         td
     in
     vtag_read_binding, (read_binding, reader_binding)
   ;;
 
   (* Generate code from type definitions *)
-  let bin_read ~f_sharp_compatible ~loc ~path (rec_flag, tds) =
+  let bin_read ~f_sharp_compatible ~loc ~path (rec_flag, tds) ~ctx_def =
     let tds = List.map tds ~f:name_type_params_in_td in
     let rec_flag = really_recursive rec_flag tds in
     (match rec_flag, tds with
@@ -1792,7 +1832,7 @@ module Generate_bin_read = struct
      | _ -> ());
     let should_omit_type_params = should_omit_type_params ~f_sharp_compatible tds in
     let vtag_read_bindings, read_and_reader_bindings =
-      List.map tds ~f:(bin_read_td ~should_omit_type_params ~loc ~path) |> List.unzip
+      List.map tds ~f:(bin_read_td ~should_omit_type_params ~loc ~path ~ctx_def) |> List.unzip
     in
     let read_bindings, reader_bindings = List.unzip read_and_reader_bindings in
     let defs =
@@ -1806,7 +1846,8 @@ module Generate_bin_read = struct
   ;;
 
   let gen =
-    Deriving.Generator.make Deriving.Args.empty (bin_read ~f_sharp_compatible:false)
+    Deriving.Generator.make (Deriving.Args.(empty +> arg "ctx" (pexp_constraint drop __)))
+       (fun ~loc ~path rec_tds ctx_arg -> bin_read ~f_sharp_compatible:false rec_tds ~loc ~path ~ctx_def:(ctx_wrapper ctx_arg))
   ;;
 
   let function_extension ~loc ~path:_ ty =
@@ -1912,6 +1953,7 @@ module Generate_tp_class = struct
       ~make_value_name:bin_name
       ~make_arg_name:bin_name
       ~body
+      ~ctx_def:NoCtx 
       td
   ;;
 
@@ -2066,7 +2108,7 @@ module For_f_sharp = struct
 
   let bin_read ~loc ~path (rec_flag, tds) =
     let structure =
-      Generate_bin_read.bin_read ~f_sharp_compatible:true ~loc ~path (rec_flag, tds)
+      Generate_bin_read.bin_read ~f_sharp_compatible:true ~ctx_def:DefaultCtx ~loc ~path (rec_flag, tds)
     in
     remove_labeled_arguments#structure structure
   ;;

--- a/test/compatibility.ml
+++ b/test/compatibility.ml
@@ -103,7 +103,7 @@ module Common = struct
     let els = Array.create ~len:10 el in
     let buf = bin_dump ~header:true bin_els.writer els in
     let pos_ref = ref 0 in
-    let els_len = Read.bin_read_int_64bit buf ~pos_ref in
+    let els_len = Read.bin_read_int_64bit ~ctx:() buf ~pos_ref in
     Expect_test_helpers_base.require_equal
       [%here]
       (module Int)
@@ -116,7 +116,7 @@ module Common = struct
       ~message:"els_len disagrees with bin_size"
       els_len
       (bin_size_els els);
-    let new_els = bin_read_els buf ~pos_ref in
+    let new_els = bin_read_els ~ctx:() buf ~pos_ref in
     Expect_test_helpers_base.require_equal
       [%here]
       (module struct
@@ -167,7 +167,7 @@ let%test_module "Inline" =
           (bin_dump inline_tc.writer x);
         let val_and_len reader =
           let pos_ref = ref 0 in
-          let x = reader.read buf ~pos_ref in
+          let x = reader.read ~ctx:() buf ~pos_ref in
           x, !pos_ref
         in
         let _, len = val_and_len derived_tc.reader in
@@ -345,7 +345,7 @@ let%test_module "Local" =
                }
                x)
             buf;
-          let x' = M.bin_read_t buf ~pos_ref:(ref 0) in
+          let x' = M.bin_read_t ~ctx:() buf ~pos_ref:(ref 0) in
           Expect_test_helpers_base.require_equal
             [%here]
             (module M)

--- a/test/deriving_inline.ml
+++ b/test/deriving_inline.ml
@@ -30,17 +30,18 @@ end = struct
 
   let _ = bin_shape_t
 
-  let (bin_size_t__local : t Bin_prot.Size.sizer_local) = function
-    | A -> 1
+  
+let bin_size_t__local : t Bin_prot.Size.sizer_local = function | A -> 1
   ;;
 
   let _ = bin_size_t__local
   let bin_size_t = (bin_size_t__local :> _ Bin_prot.Size.sizer)
   let _ = bin_size_t
 
-  let (bin_write_t__local : t Bin_prot.Write.writer_local) =
-    fun buf ~pos -> function
-    | A -> Bin_prot.Write.bin_write_int_8bit buf ~pos 0
+  
+let bin_write_t__local : t Bin_prot.Write.writer_local =
+  fun buf ~pos ->
+    function | A -> Bin_prot.Write.bin_write_int_8bit buf ~pos 0
   ;;
 
   let _ = bin_write_t__local
@@ -53,34 +54,40 @@ end = struct
 
   let _ = bin_writer_t
 
-  let (__bin_read_t__ : (int -> t) Bin_prot.Read.reader) =
-    fun _buf ~pos_ref _vint ->
-    Bin_prot.Common.raise_variant_wrong_type "deriving_inline.ml.T.t" !pos_ref
+  
+let __bin_read_t__ : (int -> t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx:_ _buf ~pos_ref _vint ->
+    Bin_prot.Common.raise_variant_wrong_type
+      "ppx_bin_prot/test/deriving_inline.ml.T.t" (!pos_ref)
   ;;
 
   let _ = __bin_read_t__
 
-  let (bin_read_t : t Bin_prot.Read.reader) =
-    fun buf ~pos_ref ->
-    match Bin_prot.Read.bin_read_int_8bit buf ~pos_ref with
+  
+let bin_read_t : (t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx buf ~pos_ref ->
+    match Bin_prot.Read.bin_read_int_8bit ~ctx buf ~pos_ref with
     | 0 -> A
     | _ ->
-      Bin_prot.Common.raise_read_error
-        (Bin_prot.Common.ReadError.Sum_tag "deriving_inline.ml.T.t")
-        !pos_ref
+        Bin_prot.Common.raise_read_error
+          (Bin_prot.Common.ReadError.Sum_tag
+             "ppx_bin_prot/test/deriving_inline.ml.T.t") (!pos_ref)
   ;;
 
   let _ = bin_read_t
 
-  let bin_reader_t =
-    ({ read = bin_read_t; vtag_read = __bin_read_t__ } : _ Bin_prot.Type_class.reader)
+  
+let bin_reader_t =
+  ({ read = bin_read_t; vtag_read = __bin_read_t__ } : (_, 'ctx)
+                                                         Bin_prot.Type_class.reader)
   ;;
 
   let _ = bin_reader_t
 
-  let bin_t =
-    ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t }
-      : _ Bin_prot.Type_class.t)
+  
+let bin_t =
+  ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t } :
+  _ Bin_prot.Type_class.t)
   ;;
 
   let _ = bin_t
@@ -175,45 +182,57 @@ end = struct
 
   let _ = bin_writer_t
 
-  let __bin_read_t__ : 'a. 'a Bin_prot.Read.reader -> (int -> 'a t) Bin_prot.Read.reader =
-    fun _of__a _buf ~pos_ref _vint ->
-    Bin_prot.Common.raise_variant_wrong_type "deriving_inline.ml.T1.t" !pos_ref
+  
+let __bin_read_t__ :
+  'a .
+    ('a, 'ctx) Bin_prot.Read.reader ->
+      (int -> 'a t, 'ctx) Bin_prot.Read.reader
+  =
+  fun _of__a ~ctx:_ _buf ~pos_ref _vint ->
+    Bin_prot.Common.raise_variant_wrong_type
+      "ppx_bin_prot/test/deriving_inline.ml.T1.t" (!pos_ref)
   ;;
 
   let _ = __bin_read_t__
 
-  let bin_read_t : 'a. 'a Bin_prot.Read.reader -> 'a t Bin_prot.Read.reader =
-    fun _of__a buf ~pos_ref ->
-    match Bin_prot.Read.bin_read_int_8bit buf ~pos_ref with
-    | 0 ->
-      let arg_1 = _of__a buf ~pos_ref in
-      A arg_1
+  
+let bin_read_t :
+  'a . ('a, 'ctx) Bin_prot.Read.reader -> ('a t, 'ctx) Bin_prot.Read.reader =
+  fun _of__a ~ctx buf ~pos_ref ->
+    match Bin_prot.Read.bin_read_int_8bit ~ctx buf ~pos_ref with
+    | 0 -> let arg_1 = _of__a ~ctx buf ~pos_ref in A arg_1
     | _ ->
-      Bin_prot.Common.raise_read_error
-        (Bin_prot.Common.ReadError.Sum_tag "deriving_inline.ml.T1.t")
-        !pos_ref
+        Bin_prot.Common.raise_read_error
+          (Bin_prot.Common.ReadError.Sum_tag
+             "ppx_bin_prot/test/deriving_inline.ml.T1.t") (!pos_ref)
   ;;
 
   let _ = bin_read_t
 
-  let bin_reader_t =
-    (fun bin_reader_a ->
-       { read = (fun buf ~pos_ref -> (bin_read_t bin_reader_a.read) buf ~pos_ref)
-       ; vtag_read =
-           (fun buf ~pos_ref vtag -> (__bin_read_t__ bin_reader_a.read) buf ~pos_ref vtag)
-       }
-      : _ Bin_prot.Type_class.reader -> _ Bin_prot.Type_class.reader)
+  
+let bin_reader_t =
+  (fun bin_reader_a ->
+     {
+       read =
+         (fun ~ctx buf ~pos_ref ->
+            (bin_read_t bin_reader_a.read) ~ctx buf ~pos_ref);
+       vtag_read =
+         (fun ~ctx buf ~pos_ref vtag ->
+            (__bin_read_t__ bin_reader_a.read) ~ctx buf ~pos_ref vtag)
+     } : (_, 'ctx) Bin_prot.Type_class.reader ->
+           (_, 'ctx) Bin_prot.Type_class.reader)
   ;;
 
   let _ = bin_reader_t
 
-  let bin_t =
-    (fun bin_a ->
-       { writer = bin_writer_t bin_a.writer
-       ; reader = bin_reader_t bin_a.reader
-       ; shape = bin_shape_t bin_a.shape
-       }
-      : _ Bin_prot.Type_class.t -> _ Bin_prot.Type_class.t)
+  
+let bin_t =
+  (fun bin_a ->
+     {
+       writer = (bin_writer_t bin_a.writer);
+       reader = (bin_reader_t bin_a.reader);
+       shape = (bin_shape_t bin_a.shape)
+     } : _ Bin_prot.Type_class.t -> _ Bin_prot.Type_class.t)
   ;;
 
   let _ = bin_t
@@ -246,15 +265,14 @@ end
 module T_read : sig
   type t [@@deriving_inline bin_read]
 
-  include sig
+  
+include
+  sig
     [@@@ocaml.warning "-32"]
-
-    val bin_read_t : t Bin_prot.Read.reader
-    val __bin_read_t__ : (int -> t) Bin_prot.Read.reader
-    val bin_reader_t : t Bin_prot.Type_class.reader
-  end
-  [@@ocaml.doc "@inline"]
-
+    val bin_read_t : (t, 'ctx) Bin_prot.Read.reader
+    val __bin_read_t__ : (int -> t, 'ctx) Bin_prot.Read.reader
+    val bin_reader_t : (t, 'ctx) Bin_prot.Type_class.reader
+  end[@@ocaml.doc "@inline"]
   [@@@end]
 end = struct
   type t [@@deriving bin_read]
@@ -263,13 +281,10 @@ end
 module T_type_class : sig
   type t [@@deriving_inline bin_type_class]
 
-  include sig
-    [@@@ocaml.warning "-32"]
-
-    val bin_t : t Bin_prot.Type_class.t
-  end
-  [@@ocaml.doc "@inline"]
-
+  
+include
+  sig [@@@ocaml.warning "-32"] val bin_t : (t, 'ctx) Bin_prot.Type_class.t
+  end[@@ocaml.doc "@inline"]
   [@@@end]
 end = struct
   type t [@@deriving bin_io]
@@ -321,20 +336,21 @@ end = struct
   let _ = bin_shape_t
   and _ = bin_shape_u
 
-  let rec (bin_size_t__local : t Bin_prot.Size.sizer_local) = function
-    | Int v1 ->
+  
+let rec bin_size_t__local : t Bin_prot.Size.sizer_local =
+  function
+  | Int v1 ->
+      let size = 1 in Bin_prot.Common.(+) size (bin_size_int__local v1)
+  | Add (v1, v2) ->
       let size = 1 in
-      Bin_prot.Common.( + ) size (bin_size_int__local v1)
-    | Add (v1, v2) ->
+      let size = Bin_prot.Common.(+) size (bin_size_u__local v1) in
+      Bin_prot.Common.(+) size (bin_size_u__local v2)
+and bin_size_u__local : u Bin_prot.Size.sizer_local =
+  function
+  | Mul (v1, v2) ->
       let size = 1 in
-      let size = Bin_prot.Common.( + ) size (bin_size_u__local v1) in
-      Bin_prot.Common.( + ) size (bin_size_u__local v2)
-
-  and (bin_size_u__local : u Bin_prot.Size.sizer_local) = function
-    | Mul (v1, v2) ->
-      let size = 1 in
-      let size = Bin_prot.Common.( + ) size (bin_size_t__local v1) in
-      Bin_prot.Common.( + ) size (bin_size_t__local v2)
+      let size = Bin_prot.Common.(+) size (bin_size_t__local v1) in
+      Bin_prot.Common.(+) size (bin_size_t__local v2)
   ;;
 
   let _ = bin_size_t__local
@@ -346,22 +362,24 @@ end = struct
   let _ = bin_size_t
   and _ = bin_size_u
 
-  let rec (bin_write_t__local : t Bin_prot.Write.writer_local) =
-    fun buf ~pos -> function
+  
+let rec bin_write_t__local : t Bin_prot.Write.writer_local =
+  fun buf ~pos ->
+    function
     | Int v1 ->
-      let pos = Bin_prot.Write.bin_write_int_8bit buf ~pos 0 in
-      bin_write_int__local buf ~pos v1
+        let pos = Bin_prot.Write.bin_write_int_8bit buf ~pos 0 in
+        bin_write_int__local buf ~pos v1
     | Add (v1, v2) ->
-      let pos = Bin_prot.Write.bin_write_int_8bit buf ~pos 1 in
-      let pos = bin_write_u__local buf ~pos v1 in
-      bin_write_u__local buf ~pos v2
-
-  and (bin_write_u__local : u Bin_prot.Write.writer_local) =
-    fun buf ~pos -> function
+        let pos = Bin_prot.Write.bin_write_int_8bit buf ~pos 1 in
+        let pos = bin_write_u__local buf ~pos v1 in
+        bin_write_u__local buf ~pos v2
+and bin_write_u__local : u Bin_prot.Write.writer_local =
+  fun buf ~pos ->
+    function
     | Mul (v1, v2) ->
-      let pos = Bin_prot.Write.bin_write_int_8bit buf ~pos 0 in
-      let pos = bin_write_t__local buf ~pos v1 in
-      bin_write_t__local buf ~pos v2
+        let pos = Bin_prot.Write.bin_write_int_8bit buf ~pos 0 in
+        let pos = bin_write_t__local buf ~pos v1 in
+        bin_write_t__local buf ~pos v2
   ;;
 
   let _ = bin_write_t__local
@@ -383,44 +401,38 @@ end = struct
   let _ = bin_writer_t
   and _ = bin_writer_u
 
-  let rec (__bin_read_t__ : (int -> t) Bin_prot.Read.reader) =
-    fun _buf ~pos_ref _vint ->
+  
+let rec __bin_read_t__ : (int -> t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx:_ _buf ~pos_ref _vint ->
     Bin_prot.Common.raise_variant_wrong_type
-      "deriving_inline.ml.Mutual_recursion.t"
-      !pos_ref
-
-  and (__bin_read_u__ : (int -> u) Bin_prot.Read.reader) =
-    fun _buf ~pos_ref _vint ->
+      "ppx_bin_prot/test/deriving_inline.ml.Mutual_recursion.t" (!pos_ref)
+and __bin_read_u__ : (int -> u, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx:_ _buf ~pos_ref _vint ->
     Bin_prot.Common.raise_variant_wrong_type
-      "deriving_inline.ml.Mutual_recursion.u"
-      !pos_ref
-
-  and (bin_read_t : t Bin_prot.Read.reader) =
-    fun buf ~pos_ref ->
-    match Bin_prot.Read.bin_read_int_8bit buf ~pos_ref with
-    | 0 ->
-      let arg_1 = bin_read_int buf ~pos_ref in
-      Int arg_1
+      "ppx_bin_prot/test/deriving_inline.ml.Mutual_recursion.u" (!pos_ref)
+and bin_read_t : (t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx buf ~pos_ref ->
+    match Bin_prot.Read.bin_read_int_8bit ~ctx buf ~pos_ref with
+    | 0 -> let arg_1 = bin_read_int ~ctx buf ~pos_ref in Int arg_1
     | 1 ->
-      let arg_1 = bin_read_u buf ~pos_ref in
-      let arg_2 = bin_read_u buf ~pos_ref in
-      Add (arg_1, arg_2)
+        let arg_1 = bin_read_u ~ctx buf ~pos_ref in
+        let arg_2 = bin_read_u ~ctx buf ~pos_ref in Add (arg_1, arg_2)
     | _ ->
-      Bin_prot.Common.raise_read_error
-        (Bin_prot.Common.ReadError.Sum_tag "deriving_inline.ml.Mutual_recursion.t")
-        !pos_ref
-
-  and (bin_read_u : u Bin_prot.Read.reader) =
-    fun buf ~pos_ref ->
-    match Bin_prot.Read.bin_read_int_8bit buf ~pos_ref with
+        Bin_prot.Common.raise_read_error
+          (Bin_prot.Common.ReadError.Sum_tag
+             "ppx_bin_prot/test/deriving_inline.ml.Mutual_recursion.t")
+          (!pos_ref)
+and bin_read_u : (u, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx buf ~pos_ref ->
+    match Bin_prot.Read.bin_read_int_8bit ~ctx buf ~pos_ref with
     | 0 ->
-      let arg_1 = bin_read_t buf ~pos_ref in
-      let arg_2 = bin_read_t buf ~pos_ref in
-      Mul (arg_1, arg_2)
+        let arg_1 = bin_read_t ~ctx buf ~pos_ref in
+        let arg_2 = bin_read_t ~ctx buf ~pos_ref in Mul (arg_1, arg_2)
     | _ ->
-      Bin_prot.Common.raise_read_error
-        (Bin_prot.Common.ReadError.Sum_tag "deriving_inline.ml.Mutual_recursion.u")
-        !pos_ref
+        Bin_prot.Common.raise_read_error
+          (Bin_prot.Common.ReadError.Sum_tag
+             "ppx_bin_prot/test/deriving_inline.ml.Mutual_recursion.u")
+          (!pos_ref)
   ;;
 
   let _ = __bin_read_t__
@@ -428,23 +440,25 @@ end = struct
   and _ = bin_read_t
   and _ = bin_read_u
 
-  let bin_reader_t =
-    ({ read = bin_read_t; vtag_read = __bin_read_t__ } : _ Bin_prot.Type_class.reader)
-
-  and bin_reader_u =
-    ({ read = bin_read_u; vtag_read = __bin_read_u__ } : _ Bin_prot.Type_class.reader)
+  
+let bin_reader_t =
+  ({ read = bin_read_t; vtag_read = __bin_read_t__ } : (_, 'ctx)
+                                                         Bin_prot.Type_class.reader)
+and bin_reader_u =
+  ({ read = bin_read_u; vtag_read = __bin_read_u__ } : (_, 'ctx)
+                                                         Bin_prot.Type_class.reader)
   ;;
 
   let _ = bin_reader_t
   and _ = bin_reader_u
 
-  let bin_t =
-    ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t }
-      : _ Bin_prot.Type_class.t)
-
-  and bin_u =
-    ({ writer = bin_writer_u; reader = bin_reader_u; shape = bin_shape_u }
-      : _ Bin_prot.Type_class.t)
+  
+let bin_t =
+  ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t } :
+  _ Bin_prot.Type_class.t)
+and bin_u =
+  ({ writer = bin_writer_u; reader = bin_reader_u; shape = bin_shape_u } :
+  _ Bin_prot.Type_class.t)
   ;;
 
   let _ = bin_t
@@ -484,20 +498,24 @@ end = struct
 
   let _ = bin_shape_t
 
-  let (bin_size_t : t Bin_prot.Size.sizer) = function
-    | v1, v2 ->
+  
+let bin_size_t : t Bin_prot.Size.sizer =
+  function
+  | (v1, v2) ->
       let size = 0 in
-      let size = Bin_prot.Common.( + ) size (bin_size_array bin_size_float v1) in
-      Bin_prot.Common.( + ) size (bin_size_list bin_size_int v2)
+      let size = Bin_prot.Common.(+) size (bin_size_array bin_size_float v1) in
+      Bin_prot.Common.(+) size (bin_size_list bin_size_int v2)
   ;;
 
   let _ = bin_size_t
 
-  let (bin_write_t : t Bin_prot.Write.writer) =
-    fun buf ~pos -> function
-    | v1, v2 ->
-      let pos = bin_write_array bin_write_float buf ~pos v1 in
-      bin_write_list bin_write_int buf ~pos v2
+  
+let bin_write_t : t Bin_prot.Write.writer =
+  fun buf ~pos ->
+    function
+    | (v1, v2) ->
+        let pos = bin_write_array bin_write_float buf ~pos v1 in
+        bin_write_list bin_write_int buf ~pos v2
   ;;
 
   let _ = bin_write_t
@@ -508,31 +526,36 @@ end = struct
 
   let _ = bin_writer_t
 
-  let (__bin_read_t__ : (int -> t) Bin_prot.Read.reader) =
-    fun _buf ~pos_ref _vint ->
-    Bin_prot.Common.raise_variant_wrong_type "deriving_inline.ml.Float_array.t" !pos_ref
+  
+let __bin_read_t__ : (int -> t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx:_ _buf ~pos_ref _vint ->
+    Bin_prot.Common.raise_variant_wrong_type
+      "ppx_bin_prot/test/deriving_inline.ml.Float_array.t" (!pos_ref)
   ;;
 
   let _ = __bin_read_t__
 
-  let (bin_read_t : t Bin_prot.Read.reader) =
-    fun buf ~pos_ref ->
-    let v1 = (bin_read_array bin_read_float) buf ~pos_ref in
-    let v2 = (bin_read_list bin_read_int) buf ~pos_ref in
-    v1, v2
+  
+let bin_read_t : (t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx buf ~pos_ref ->
+    let v1 = (bin_read_array bin_read_float) ~ctx buf ~pos_ref in
+    let v2 = (bin_read_list bin_read_int) ~ctx buf ~pos_ref in (v1, v2)
   ;;
 
   let _ = bin_read_t
 
-  let bin_reader_t =
-    ({ read = bin_read_t; vtag_read = __bin_read_t__ } : _ Bin_prot.Type_class.reader)
+  
+let bin_reader_t =
+  ({ read = bin_read_t; vtag_read = __bin_read_t__ } : (_, 'ctx)
+                                                         Bin_prot.Type_class.reader)
   ;;
 
   let _ = bin_reader_t
 
-  let bin_t =
-    ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t }
-      : _ Bin_prot.Type_class.t)
+  
+let bin_t =
+  ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t } :
+  _ Bin_prot.Type_class.t)
   ;;
 
   let _ = bin_t
@@ -564,6 +587,7 @@ end = struct
   module Extension_global = T
 
   module Record = struct
+    [@@@warning "-69"]
     type t =
       { a : Normal.t
       ; mutable b : Mutable.t
@@ -595,28 +619,32 @@ end = struct
 
     let _ = bin_shape_t
 
-    let (bin_size_t__local : t Bin_prot.Size.sizer_local) = function
-      | { a = v1; b = v2; c = v3; d = v4; e = v5 } ->
-        let size = 0 in
-        let size = Bin_prot.Common.( + ) size (Normal.bin_size_t__local v1) in
-        let size = Bin_prot.Common.( + ) size (Mutable.bin_size_t v2) in
-        let size = Bin_prot.Common.( + ) size (Global.bin_size_t v3) in
-        let size = Bin_prot.Common.( + ) size (Ocaml_global.bin_size_t v4) in
-        Bin_prot.Common.( + ) size (Extension_global.bin_size_t v5)
+    
+let bin_size_t__local : t Bin_prot.Size.sizer_local =
+  function
+  | { a = v1; b = v2; c = v3; d = v4; e = v5 } ->
+      let size = 0 in
+      let size = Bin_prot.Common.(+) size (Normal.bin_size_t__local v1) in
+      let size = Bin_prot.Common.(+) size (Mutable.bin_size_t v2) in
+      let size = Bin_prot.Common.(+) size (Global.bin_size_t__local v3) in
+      let size = Bin_prot.Common.(+) size (Ocaml_global.bin_size_t__local v4) in
+      Bin_prot.Common.(+) size (Extension_global.bin_size_t__local v5)
     ;;
 
     let _ = bin_size_t__local
     let bin_size_t = (bin_size_t__local :> _ Bin_prot.Size.sizer)
     let _ = bin_size_t
 
-    let (bin_write_t__local : t Bin_prot.Write.writer_local) =
-      fun buf ~pos -> function
-      | { a = v1; b = v2; c = v3; d = v4; e = v5 } ->
+    
+let bin_write_t__local : t Bin_prot.Write.writer_local =
+  fun buf ~pos ->
+    function
+    | { a = v1; b = v2; c = v3; d = v4; e = v5 } ->
         let pos = Normal.bin_write_t__local buf ~pos v1 in
         let pos = Mutable.bin_write_t buf ~pos v2 in
-        let pos = Global.bin_write_t buf ~pos v3 in
-        let pos = Ocaml_global.bin_write_t buf ~pos v4 in
-        Extension_global.bin_write_t buf ~pos v5
+        let pos = Global.bin_write_t__local buf ~pos v3 in
+        let pos = Ocaml_global.bin_write_t__local buf ~pos v4 in
+        Extension_global.bin_write_t__local buf ~pos v5
     ;;
 
     let _ = bin_write_t__local
@@ -629,36 +657,41 @@ end = struct
 
     let _ = bin_writer_t
 
-    let (__bin_read_t__ : (int -> t) Bin_prot.Read.reader) =
-      fun _buf ~pos_ref _vint ->
-      Bin_prot.Common.raise_variant_wrong_type
-        "deriving_inline.ml.Global_fields_with_localize.Record.t"
-        !pos_ref
+    
+let __bin_read_t__ : (int -> t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx:_ _buf ~pos_ref _vint ->
+    Bin_prot.Common.raise_variant_wrong_type
+      "ppx_bin_prot/test/deriving_inline.ml.Global_fields_with_localize.Record.t"
+      (!pos_ref)
     ;;
 
     let _ = __bin_read_t__
 
-    let (bin_read_t : t Bin_prot.Read.reader) =
-      fun buf ~pos_ref ->
-      let v_a = Normal.bin_read_t buf ~pos_ref in
-      let v_b = Mutable.bin_read_t buf ~pos_ref in
-      let v_c = Global.bin_read_t buf ~pos_ref in
-      let v_d = Ocaml_global.bin_read_t buf ~pos_ref in
-      let v_e = Extension_global.bin_read_t buf ~pos_ref in
-      { a = v_a; b = v_b; c = v_c; d = v_d; e = v_e }
+    
+let bin_read_t : (t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx buf ~pos_ref ->
+    let v_a = Normal.bin_read_t ~ctx buf ~pos_ref in
+    let v_b = Mutable.bin_read_t ~ctx buf ~pos_ref in
+    let v_c = Global.bin_read_t ~ctx buf ~pos_ref in
+    let v_d = Ocaml_global.bin_read_t ~ctx buf ~pos_ref in
+    let v_e = Extension_global.bin_read_t ~ctx buf ~pos_ref in
+    { a = v_a; b = v_b; c = v_c; d = v_d; e = v_e }
     ;;
 
     let _ = bin_read_t
 
-    let bin_reader_t =
-      ({ read = bin_read_t; vtag_read = __bin_read_t__ } : _ Bin_prot.Type_class.reader)
+    
+let bin_reader_t =
+  ({ read = bin_read_t; vtag_read = __bin_read_t__ } : (_, 'ctx)
+                                                         Bin_prot.Type_class.reader)
     ;;
 
     let _ = bin_reader_t
 
-    let bin_t =
-      ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t }
-        : _ Bin_prot.Type_class.t)
+    
+let bin_t =
+  ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t } :
+  _ Bin_prot.Type_class.t)
     ;;
 
     let _ = bin_t
@@ -667,6 +700,7 @@ end = struct
   end
 
   module Record_constructor = struct
+    [@@@warning "-69"]
     type t =
       | T of
           { a : Normal.t
@@ -703,29 +737,33 @@ end = struct
 
     let _ = bin_shape_t
 
-    let (bin_size_t__local : t Bin_prot.Size.sizer_local) = function
-      | T { a = v1; b = v2; c = v3; d = v4; e = v5 } ->
-        let size = 1 in
-        let size = Bin_prot.Common.( + ) size (Normal.bin_size_t__local v1) in
-        let size = Bin_prot.Common.( + ) size (Mutable.bin_size_t v2) in
-        let size = Bin_prot.Common.( + ) size (Global.bin_size_t v3) in
-        let size = Bin_prot.Common.( + ) size (Ocaml_global.bin_size_t v4) in
-        Bin_prot.Common.( + ) size (Extension_global.bin_size_t v5)
+    
+let bin_size_t__local : t Bin_prot.Size.sizer_local =
+  function
+  | T { a = v1; b = v2; c = v3; d = v4; e = v5 } ->
+      let size = 1 in
+      let size = Bin_prot.Common.(+) size (Normal.bin_size_t__local v1) in
+      let size = Bin_prot.Common.(+) size (Mutable.bin_size_t v2) in
+      let size = Bin_prot.Common.(+) size (Global.bin_size_t__local v3) in
+      let size = Bin_prot.Common.(+) size (Ocaml_global.bin_size_t__local v4) in
+      Bin_prot.Common.(+) size (Extension_global.bin_size_t__local v5)
     ;;
 
     let _ = bin_size_t__local
     let bin_size_t = (bin_size_t__local :> _ Bin_prot.Size.sizer)
     let _ = bin_size_t
 
-    let (bin_write_t__local : t Bin_prot.Write.writer_local) =
-      fun buf ~pos -> function
-      | T { a = v1; b = v2; c = v3; d = v4; e = v5 } ->
+    
+let bin_write_t__local : t Bin_prot.Write.writer_local =
+  fun buf ~pos ->
+    function
+    | T { a = v1; b = v2; c = v3; d = v4; e = v5 } ->
         let pos = Bin_prot.Write.bin_write_int_8bit buf ~pos 0 in
         let pos = Normal.bin_write_t__local buf ~pos v1 in
         let pos = Mutable.bin_write_t buf ~pos v2 in
-        let pos = Global.bin_write_t buf ~pos v3 in
-        let pos = Ocaml_global.bin_write_t buf ~pos v4 in
-        Extension_global.bin_write_t buf ~pos v5
+        let pos = Global.bin_write_t__local buf ~pos v3 in
+        let pos = Ocaml_global.bin_write_t__local buf ~pos v4 in
+        Extension_global.bin_write_t__local buf ~pos v5
     ;;
 
     let _ = bin_write_t__local
@@ -738,43 +776,48 @@ end = struct
 
     let _ = bin_writer_t
 
-    let (__bin_read_t__ : (int -> t) Bin_prot.Read.reader) =
-      fun _buf ~pos_ref _vint ->
-      Bin_prot.Common.raise_variant_wrong_type
-        "deriving_inline.ml.Global_fields_with_localize.Record_constructor.t"
-        !pos_ref
+    
+let __bin_read_t__ : (int -> t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx:_ _buf ~pos_ref _vint ->
+    Bin_prot.Common.raise_variant_wrong_type
+      "ppx_bin_prot/test/deriving_inline.ml.Global_fields_with_localize.Record_constructor.t"
+      (!pos_ref)
     ;;
 
     let _ = __bin_read_t__
 
-    let (bin_read_t : t Bin_prot.Read.reader) =
-      fun buf ~pos_ref ->
-      match Bin_prot.Read.bin_read_int_8bit buf ~pos_ref with
-      | 0 ->
-        let v_a = Normal.bin_read_t buf ~pos_ref in
-        let v_b = Mutable.bin_read_t buf ~pos_ref in
-        let v_c = Global.bin_read_t buf ~pos_ref in
-        let v_d = Ocaml_global.bin_read_t buf ~pos_ref in
-        let v_e = Extension_global.bin_read_t buf ~pos_ref in
+    
+let bin_read_t : (t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx buf ~pos_ref ->
+    match Bin_prot.Read.bin_read_int_8bit ~ctx buf ~pos_ref with
+    | 0 ->
+        let v_a = Normal.bin_read_t ~ctx buf ~pos_ref in
+        let v_b = Mutable.bin_read_t ~ctx buf ~pos_ref in
+        let v_c = Global.bin_read_t ~ctx buf ~pos_ref in
+        let v_d = Ocaml_global.bin_read_t ~ctx buf ~pos_ref in
+        let v_e = Extension_global.bin_read_t ~ctx buf ~pos_ref in
         T { a = v_a; b = v_b; c = v_c; d = v_d; e = v_e }
-      | _ ->
+    | _ ->
         Bin_prot.Common.raise_read_error
           (Bin_prot.Common.ReadError.Sum_tag
-             "deriving_inline.ml.Global_fields_with_localize.Record_constructor.t")
-          !pos_ref
+             "ppx_bin_prot/test/deriving_inline.ml.Global_fields_with_localize.Record_constructor.t")
+          (!pos_ref)
     ;;
 
     let _ = bin_read_t
 
-    let bin_reader_t =
-      ({ read = bin_read_t; vtag_read = __bin_read_t__ } : _ Bin_prot.Type_class.reader)
+    
+let bin_reader_t =
+  ({ read = bin_read_t; vtag_read = __bin_read_t__ } : (_, 'ctx)
+                                                         Bin_prot.Type_class.reader)
     ;;
 
     let _ = bin_reader_t
 
-    let bin_t =
-      ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t }
-        : _ Bin_prot.Type_class.t)
+    
+let bin_t =
+  ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t } :
+  _ Bin_prot.Type_class.t)
     ;;
 
     let _ = bin_t
@@ -809,27 +852,31 @@ end = struct
 
     let _ = bin_shape_t
 
-    let (bin_size_t__local : t Bin_prot.Size.sizer_local) = function
-      | T (v1, v2, v3, v4) ->
-        let size = 1 in
-        let size = Bin_prot.Common.( + ) size (Normal.bin_size_t__local v1) in
-        let size = Bin_prot.Common.( + ) size (Global.bin_size_t v2) in
-        let size = Bin_prot.Common.( + ) size (Ocaml_global.bin_size_t v3) in
-        Bin_prot.Common.( + ) size (Extension_global.bin_size_t v4)
+    
+let bin_size_t__local : t Bin_prot.Size.sizer_local =
+  function
+  | T (v1, v2, v3, v4) ->
+      let size = 1 in
+      let size = Bin_prot.Common.(+) size (Normal.bin_size_t__local v1) in
+      let size = Bin_prot.Common.(+) size (Global.bin_size_t__local v2) in
+      let size = Bin_prot.Common.(+) size (Ocaml_global.bin_size_t__local v3) in
+      Bin_prot.Common.(+) size (Extension_global.bin_size_t__local v4)
     ;;
 
     let _ = bin_size_t__local
     let bin_size_t = (bin_size_t__local :> _ Bin_prot.Size.sizer)
     let _ = bin_size_t
 
-    let (bin_write_t__local : t Bin_prot.Write.writer_local) =
-      fun buf ~pos -> function
-      | T (v1, v2, v3, v4) ->
+    
+let bin_write_t__local : t Bin_prot.Write.writer_local =
+  fun buf ~pos ->
+    function
+    | T (v1, v2, v3, v4) ->
         let pos = Bin_prot.Write.bin_write_int_8bit buf ~pos 0 in
         let pos = Normal.bin_write_t__local buf ~pos v1 in
-        let pos = Global.bin_write_t buf ~pos v2 in
-        let pos = Ocaml_global.bin_write_t buf ~pos v3 in
-        Extension_global.bin_write_t buf ~pos v4
+        let pos = Global.bin_write_t__local buf ~pos v2 in
+        let pos = Ocaml_global.bin_write_t__local buf ~pos v3 in
+        Extension_global.bin_write_t__local buf ~pos v4
     ;;
 
     let _ = bin_write_t__local
@@ -842,42 +889,47 @@ end = struct
 
     let _ = bin_writer_t
 
-    let (__bin_read_t__ : (int -> t) Bin_prot.Read.reader) =
-      fun _buf ~pos_ref _vint ->
-      Bin_prot.Common.raise_variant_wrong_type
-        "deriving_inline.ml.Global_fields_with_localize.Tuple_constructor.t"
-        !pos_ref
+    
+let __bin_read_t__ : (int -> t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx:_ _buf ~pos_ref _vint ->
+    Bin_prot.Common.raise_variant_wrong_type
+      "ppx_bin_prot/test/deriving_inline.ml.Global_fields_with_localize.Tuple_constructor.t"
+      (!pos_ref)
     ;;
 
     let _ = __bin_read_t__
 
-    let (bin_read_t : t Bin_prot.Read.reader) =
-      fun buf ~pos_ref ->
-      match Bin_prot.Read.bin_read_int_8bit buf ~pos_ref with
-      | 0 ->
-        let arg_1 = Normal.bin_read_t buf ~pos_ref in
-        let arg_2 = Global.bin_read_t buf ~pos_ref in
-        let arg_3 = Ocaml_global.bin_read_t buf ~pos_ref in
-        let arg_4 = Extension_global.bin_read_t buf ~pos_ref in
+    
+let bin_read_t : (t, 'ctx) Bin_prot.Read.reader =
+  fun ~ctx buf ~pos_ref ->
+    match Bin_prot.Read.bin_read_int_8bit ~ctx buf ~pos_ref with
+    | 0 ->
+        let arg_1 = Normal.bin_read_t ~ctx buf ~pos_ref in
+        let arg_2 = Global.bin_read_t ~ctx buf ~pos_ref in
+        let arg_3 = Ocaml_global.bin_read_t ~ctx buf ~pos_ref in
+        let arg_4 = Extension_global.bin_read_t ~ctx buf ~pos_ref in
         T (arg_1, arg_2, arg_3, arg_4)
-      | _ ->
+    | _ ->
         Bin_prot.Common.raise_read_error
           (Bin_prot.Common.ReadError.Sum_tag
-             "deriving_inline.ml.Global_fields_with_localize.Tuple_constructor.t")
-          !pos_ref
+             "ppx_bin_prot/test/deriving_inline.ml.Global_fields_with_localize.Tuple_constructor.t")
+          (!pos_ref)
     ;;
 
     let _ = bin_read_t
 
-    let bin_reader_t =
-      ({ read = bin_read_t; vtag_read = __bin_read_t__ } : _ Bin_prot.Type_class.reader)
+    
+let bin_reader_t =
+  ({ read = bin_read_t; vtag_read = __bin_read_t__ } : (_, 'ctx)
+                                                         Bin_prot.Type_class.reader)
     ;;
 
     let _ = bin_reader_t
 
-    let bin_t =
-      ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t }
-        : _ Bin_prot.Type_class.t)
+    
+let bin_t =
+  ({ writer = bin_writer_t; reader = bin_reader_t; shape = bin_shape_t } :
+  _ Bin_prot.Type_class.t)
     ;;
 
     let _ = bin_t

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,6 @@
 (library
  (name ppx_bin_prot_tests)
- (libraries core expect_test_helpers_core)
+ (libraries bin_prot core expect_test_helpers_core)
+ (inline_tests (flags (:standard -drop-tag js-only -drop-tag 32-bits-only)))
  (preprocess
-  (pps ppx_jane)))
+  (pps ppx_jane ppx_bin_prot)))

--- a/test/example.ml
+++ b/test/example.ml
@@ -4,6 +4,9 @@ module type S = sig
   type t [@@deriving bin_io ~localize]
 end
 
+module type S_with_ctx = sig
+end
+
 module type S1 = sig
   type 'a t [@@deriving bin_io ~localize]
 end

--- a/test/extension_tests.ml
+++ b/test/extension_tests.ml
@@ -19,8 +19,8 @@ module _ = struct
   let _ = [%bin_size: t]
   let _ = [%bin_write: t]
   let _ = [%bin_writer: t]
-  let (_ : t Bin_prot.Read.reader) = [%bin_read: t]
-  let (_ : t Bin_prot.Type_class.reader) = [%bin_reader: t]
+  let (_ : (t, _) Bin_prot.Read.reader) = [%bin_read: t]
+  let (_ : (t, _) Bin_prot.Type_class.reader) = [%bin_reader: t]
   let _ = [%bin_type_class: t]
 end
 
@@ -38,8 +38,8 @@ module _ = struct
   let _ = [%bin_size: [ `A | `B of int ]]
   let _ = [%bin_write: [ `A | `B of int ]]
   let _ = [%bin_writer: [ `A | `B of int ]]
-  let (_ : t Bin_prot.Read.reader) = [%bin_read: [ `A | `B of int ]]
-  let (_ : t Bin_prot.Type_class.reader) = [%bin_reader: [ `A | `B of int ]]
+  let (_ : (t, _) Bin_prot.Read.reader) = [%bin_read: [ `A | `B of int ]]
+  let (_ : (t, _) Bin_prot.Type_class.reader) = [%bin_reader: [ `A | `B of int ]]
   let _ = [%bin_type_class: [ `A | `B of int ]]
 end
 
@@ -87,7 +87,7 @@ let test
               (written_size : int)
               ~written:(Bigstring.sub message ~pos:0 ~len:written_size : Bigstring.t)];
       let pos_ref = ref 0 in
-      let round_trip = bin_read message ~pos_ref in
+      let round_trip = bin_read ~ctx:() message ~pos_ref in
       let read_size = !pos_ref in
       require
         [%here]


### PR DESCRIPTION
…r` (with `~ctx:("_":c)`).

This is the companion to https://github.com/janestreet/bin_prot/pull/34 .